### PR TITLE
Fix for SitecronSavedHandler exception message

### DIFF
--- a/Code/Sitecron/Events/SitecronSavedHandler.cs
+++ b/Code/Sitecron/Events/SitecronSavedHandler.cs
@@ -2,6 +2,7 @@
 using Sitecore.Events;
 using Sitecron.SitecronSettings;
 using System;
+using Sitecore.Data.Events;
 
 namespace Sitecron.Events
 {
@@ -9,7 +10,17 @@ namespace Sitecron.Events
     {
         public void OnItemSaved(object sender, EventArgs args)
         {
-            Item savedItem = Event.ExtractParameter(args, 0) as Item;
+            Item savedItem = null;
+            ItemSavedRemoteEventArgs remoteArgs = args as ItemSavedRemoteEventArgs;
+            
+            if (remoteArgs != null)
+            {
+                savedItem = remoteArgs.Item;
+            }
+            else
+            {
+                savedItem = Event.ExtractParameter(args, 0) as Item;
+            }
 
             if (savedItem != null && SitecronConstants.Templates.SitecronJobTemplateID == savedItem.TemplateID) //matched Sitecron job template
             {

--- a/Code/Sitecron/Jobs/HelloWorld.cs
+++ b/Code/Sitecron/Jobs/HelloWorld.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Quartz;
+using Sitecore.Diagnostics;
+
+namespace Sitecron.Jobs
+{
+    public class HelloWorld : IJob
+    {
+        public void Execute(IJobExecutionContext context)
+        {
+            Log.Info("Sitecron - Hello World", this);
+        }
+    }
+}

--- a/Code/Sitecron/Sitecron.csproj
+++ b/Code/Sitecron/Sitecron.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Events\SitecronDeletedHandler.cs" />
     <Compile Include="Events\SitecronSavedHandler.cs" />
     <Compile Include="InitializeSitecron.cs" />
+    <Compile Include="Jobs\HelloWorld.cs" />
     <Compile Include="Jobs\PowerShell\ExecuteScript.cs" />
     <Compile Include="Jobs\Publishing\SmartPublish.cs" />
     <Compile Include="Listeners\CustomJobListener.cs" />


### PR DESCRIPTION
Fixes for the following exception message:

Sitecore.Data.Events.ItemSavedRemoteEventArgs. Expected: SitecoreEventArgs 
Source[1]: Sitecore.Kernel 
   at Sitecore.Events.Event.ExtractParameters(EventArgs args)
   at Sitecore.Events.Event.ExtractParameter(EventArgs args, Int32 index)
   at Sitecron.Events.SitecronSavedHandler.OnItemSaved(Object sender, EventArgs args)
   at Sitecore.Events.Event.EventSubscribers.RaiseEvent(String eventName, Object[] parameters, EventResult result) 

