### PR TITLE
Fix for smart publish job won't accept parameter.

### DIFF
--- a/Code/Sitecron/Core/Scheduling/QuartzSitecronScheduler.cs
+++ b/Code/Sitecron/Core/Scheduling/QuartzSitecronScheduler.cs
@@ -69,7 +69,7 @@ namespace Sitecron.Core.Scheduling
         protected IJobDetail CreateJobDetail(SitecronJob job)
         {
             var jobDetail = JobBuilder.Create(job.JobType).Build();
-            var jobParams = string.IsNullOrEmpty(job.Parameters) ? job.Parameters + "&" : string.Empty;
+            var jobParams = !string.IsNullOrEmpty(job.Parameters) ? job.Parameters + "&" : string.Empty;
             jobParams += $"{SitecronConstants.ParamNames.zSiteCronItemID}={job.ItemId}";
             jobDetail.JobDataMap.Add(SitecronConstants.FieldNames.Parameters, jobParams);
 


### PR DESCRIPTION
Fixing ternary expression for adding parameters to job detail.