### PR TITLE
Created logging config for Azure PaaS

### DIFF
--- a/Code/Sitecron/App_Config/Include/Z.SiteCron/zSiteCron.Azure.config.disabled
+++ b/Code/Sitecron/App_Config/Include/Z.SiteCron/zSiteCron.Azure.config.disabled
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+  <sitecore>
+    <log4net>
+      <appender name="SitecronLogFileAppender">
+        <patch:attribute name="type">Sitecore.Cloud.ApplicationInsights.Logging.LevelTraceAppender, Sitecore.Cloud.ApplicationInsights</patch:attribute>
+        <file>
+          <patch:delete />
+        </file>
+        <appendToFile>
+          <patch:delete />
+        </appendToFile>
+        <encoding>
+          <patch:delete />
+        </encoding>
+      </appender>
+  </sitecore>
+</configuration>

--- a/Code/Sitecron/Sitecron.csproj
+++ b/Code/Sitecron/Sitecron.csproj
@@ -125,6 +125,7 @@
     <Content Include="App_Config\Include\Z.SiteCron\SiteCron.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="App_Config\Include\Z.SiteCron\zSiteCron.Azure.config.disabled" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config">


### PR DESCRIPTION
Azure PaaS loggers are a bit different as they need to stream to app insights. These config changes will allow it to do so. 