### PR TITLE
Fix Issue #24: "One or more exceptions occurred while processing the subscribers to the 'item:deleted:remote' event"

### DIFF
--- a/Code/Sitecron/Core/Events/SitecronDeletedHandler.cs
+++ b/Code/Sitecron/Core/Events/SitecronDeletedHandler.cs
@@ -1,11 +1,11 @@
-﻿using Sitecore.Data;
+﻿using System;
+using Sitecore.Data;
 using Sitecore.Data.Events;
 using Sitecore.Data.Items;
 using Sitecore.Data.Managers;
 using Sitecore.Diagnostics;
 using Sitecore.Events;
 using Sitecron.SitecronSettings;
-using System;
 
 namespace Sitecron.Core.Events
 {
@@ -26,7 +26,7 @@ namespace Sitecron.Core.Events
             if (remoteArgs != null)
             {
                 deletedItem = remoteArgs.Item;
-                parentId = Event.ExtractParameter(remoteArgs, 1) as ID;
+                parentId = remoteArgs.ParentId;
             }
             else
             {


### PR DESCRIPTION
The error occurs when extracting "ParentID" from the "args" parameter because the "ExtractParameters" method would work with a "SitecoreEventArgs", but we have an "ItemDeletedRemoteEventArgs" and that's why we get the error.

![image](https://user-images.githubusercontent.com/54404621/217819802-a701af7f-25c0-4d49-a154-6ce473cdab21.png)

![image](https://user-images.githubusercontent.com/54404621/217819866-0c014689-8a33-4c48-ae95-0e1baa92769a.png)
